### PR TITLE
Add support page and fix syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Adobe I/O Console Developer's Guide
-Adobe I/O Console is the the developer's tool for managing the relationship betwwen their applications and Adobe technology. Through the Console, developers can create and manage projects that communicate and collaborate with Adobe:
+Adobe I/O Console is the developer's tool for managing the relationship between their applications and Adobe technology. Through the Console, developers can create and manage projects that communicate and collaborate with Adobe:
 
 - [Integrations](integrations.md): Applications you create that leverage the power of Adobe products and technologies through the publicly accessible Adobe REST API.
 - [Plugins](plugins.md): Applications you create that enhance the functionality of Adobe products and are accessed through the UI of those products. These are typically available through the Adobe Marketplace.

--- a/manifest.json
+++ b/manifest.json
@@ -1,32 +1,32 @@
 {
-"name": "Console",
-"version": "1.0.0",
-"description": "Adobe I/O Console Developer's Guide",
-"author": "Matt Lusher",
-"view_type": "mdbook",
-"meta_keywords": "adobe i/o,console,integrations,plugins",
-"meta_description": "Documentation for features of the Adobe I/O Console for developers.",
-"publish_date": "03/22/2019",
-"show_edit_github_banner": false,
-"base_path": "https://raw.githubusercontent.com",
-"pages": [
-	{
-      "importedFileName": "overview",
-      "pages": [],
-			"path": "adobedocs/adobeio-console/master/README.md",
-			"title": "Overview"
-	},
-	{
-      "importedFileName": "integrations",
-      "pages": [],
-      "path": "adobedocs/adobeio-console/master/integrations.md",
-      "title": "Creating an Integration"
-	},
-	{
-      "importedFileName": "plugins",
-      "pages": [],
-      "path": "adobedocs/adobeio-console/master/plugins.md",
-      "title": "Creating an Integration"
-	}
-]
+  "name": "Console",
+  "version": "1.0.0",
+  "description": "Adobe I/O Console Developer's Guide",
+  "author": "Matt Lusher",
+  "view_type": "mdbook",
+  "meta_keywords": "adobe i/o,console,integrations,plugins",
+  "meta_description": "Documentation for features of the Adobe I/O Console for developers.",
+  "publish_date": "03/22/2019",
+  "show_edit_github_banner": false,
+  "base_path": "https://raw.githubusercontent.com",
+  "pages": [
+    {
+        "importedFileName": "overview",
+        "pages": [],
+        "path": "adobedocs/adobeio-console/master/README.md",
+        "title": "Overview"
+    },
+    {
+        "importedFileName": "integrations",
+        "pages": [],
+        "path": "adobedocs/adobeio-console/master/integrations.md",
+        "title": "Creating an Integration"
+    },
+    {
+        "importedFileName": "plugins",
+        "pages": [],
+        "path": "adobedocs/adobeio-console/master/plugins.md",
+        "title": "Creating an Integration"
+    }
+  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,12 @@
         "pages": [],
         "path": "AdobeDocs/adobeio-console/master/faq.md",
         "title": "FAQ"
+    },
+    {
+        "importedFileName": "support",
+        "pages": [],
+        "path": "AdobeDocs/adobeio-console/master/support.md",
+        "title": "Support"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,12 @@
 "show_edit_github_banner": false,
 "base_path": "https://raw.githubusercontent.com",
 "pages": [
-{
-"importedFileName": "README",
-"pages": [
+	{
+      "importedFileName": "overview",
+      "pages": [],
+			"path": "adobedocs/adobeio-console/master/README.md",
+			"title": "Overview"
+	},
 	{
       "importedFileName": "integrations",
       "pages": [],
@@ -25,9 +28,5 @@
       "path": "adobedocs/adobeio-console/master/plugins.md",
       "title": "Creating an Integration"
 	}
-	],
-	 "path": "adobedocs/adobeio-console/master/README.md",
-     "title": "Adobe I/O Console Developer's Guide"
-	 }
-	 ]
+]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -13,20 +13,26 @@
     {
         "importedFileName": "overview",
         "pages": [],
-        "path": "adobedocs/adobeio-console/master/README.md",
+        "path": "AdobeDocs/adobeio-console/master/README.md",
         "title": "Overview"
     },
     {
         "importedFileName": "integrations",
         "pages": [],
-        "path": "adobedocs/adobeio-console/master/integrations.md",
+        "path": "AdobeDocs/adobeio-console/master/integrations.md",
         "title": "Creating an Integration"
     },
     {
         "importedFileName": "plugins",
         "pages": [],
-        "path": "adobedocs/adobeio-console/master/plugins.md",
+        "path": "AdobeDocs/adobeio-console/master/plugins.md",
         "title": "Creating an Integration"
+    },
+    {
+        "importedFileName": "faq",
+        "pages": [],
+        "path": "AdobeDocs/adobeio-console/master/faq.md",
+        "title": "FAQ"
     }
   ]
 }

--- a/support.md
+++ b/support.md
@@ -1,0 +1,15 @@
+# Support
+
+Learn where to ask questions, report bugs, make feature requests, and spark discussions.
+
+## [FAQ](faq.md)
+
+A knowledge base of frequently asked questions. This is a great starting place to find an answer before asking your question.
+
+## [Adobe Forums](https://forums.adobe.com/community/adobe-io/adobe-io-console)
+
+Ask questions and find answers from our developer community on the Adobe Forums.
+
+## [GitHub Issues](https://github.com/AdobeDocs/adobeio-console/issues)
+
+This is the place to report bugs, ask questions, make feature requests, or start a discussion. You'll find official Adobe developers and community members available to help you out.


### PR DESCRIPTION
There are a number of changes included in this pull request:
- Fixed `README.md` spelling mistakes
- Fix `manifest.json` syntax errors (it was invalid JSON)
- Refactored `manifest.json` to use LF and tabs
- Added FAQ link to `manifest.json` (so that it appears in the side navigation on the website)
- Add Support link to `manifest.json` (so that it appears in the side navigation on the website)
- Added Support page
  - I put the _Adobe Forum_ above the _GitHub Issues_ link because I think the I/O Console team wants to encourage people to use the Forums. You can swap this order if you want to encourage people to use _GitHub Issues_ more.