### PR TITLE
Fix manifest.json reference to master in stage branch

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,31 +13,31 @@
     {
         "importedFileName": "overview",
         "pages": [],
-        "path": "AdobeDocs/adobeio-console/master/README.md",
+        "path": "AdobeDocs/adobeio-console/stage/README.md",
         "title": "Overview"
     },
     {
         "importedFileName": "integrations",
         "pages": [],
-        "path": "AdobeDocs/adobeio-console/master/integrations.md",
+        "path": "AdobeDocs/adobeio-console/stage/integrations.md",
         "title": "Creating an Integration"
     },
     {
         "importedFileName": "plugins",
         "pages": [],
-        "path": "AdobeDocs/adobeio-console/master/plugins.md",
+        "path": "AdobeDocs/adobeio-console/stage/plugins.md",
         "title": "Creating an Integration"
     },
     {
         "importedFileName": "faq",
         "pages": [],
-        "path": "AdobeDocs/adobeio-console/master/faq.md",
+        "path": "AdobeDocs/adobeio-console/stage/faq.md",
         "title": "FAQ"
     },
     {
         "importedFileName": "support",
         "pages": [],
-        "path": "AdobeDocs/adobeio-console/master/support.md",
+        "path": "AdobeDocs/adobeio-console/stage/support.md",
         "title": "Support"
     }
   ]


### PR DESCRIPTION
This is a minor fix, but I'd appreciate a review to ensure that I'm sending the PR to the correct branch/workflow.

## Problem

I noticed that the `stage` branch has references to `master` in the `manifest.json`. This causes the stage environment to display incorrect content from the production environment.

## Solution

Update the `manifest.json` in the `stage` branch to use stage paths.